### PR TITLE
Form as pop up in Watchlist

### DIFF
--- a/client/src/GlobalStyle.js
+++ b/client/src/GlobalStyle.js
@@ -35,7 +35,7 @@ textarea,
 button {
   font-size: 1.25rem;
   font-family: sans-serif;
-  color: var(--grey-darkest)
+  color: var(--grey-darkest);
 }
 
 body {
@@ -61,6 +61,12 @@ h2 {
 
 h3 {
   font-size: 1.375rem;
+}
+
+input,
+select,
+textarea {
+  border: 0.06rem var(--grey-darkest) solid;
 }
 
 ul {

--- a/client/src/components/Footer.js
+++ b/client/src/components/Footer.js
@@ -27,6 +27,7 @@ const FooterStyled = styled.footer`
   bottom: 0;
   left: 0;
   right: 0;
+  z-index: 1000;
 `;
 
 const Nav = styled.nav`

--- a/client/src/components/WatchlistCard.js
+++ b/client/src/components/WatchlistCard.js
@@ -32,6 +32,8 @@ export default function WatchlistCard({
 
 const Card = styled.article`
   width: 85vw;
+  max-width: 20rem;
+
   box-shadow: 0.3rem 0.3rem 0.8rem var(--grey-light);
   border-radius: 1.8rem;
   padding: 2rem;

--- a/client/src/components/WatchlistCard.js
+++ b/client/src/components/WatchlistCard.js
@@ -8,8 +8,13 @@ export default function WatchlistCard({
   item,
   onCheckItem,
   onSetItemToBeEdited,
+  onSetFormOnScreen,
   onRemoveFromWatchlist
 }) {
+  function handleClickOnEdit(clickedItem) {
+    onSetItemToBeEdited(clickedItem);
+    onSetFormOnScreen(true);
+  }
   return (
     <Card>
       {item.title ? <h4>{item.title}</h4> : <h4>Ohne Titel</h4>}
@@ -18,15 +23,15 @@ export default function WatchlistCard({
         <button onClick={() => onCheckItem(item)}>
           {displayButtonText(item.category)}
         </button>
-        <button onClick={() => onSetItemToBeEdited(item)}>bearbeiten</button>
+        <button onClick={() => handleClickOnEdit(item)}>bearbeiten</button>
         <button onClick={() => onRemoveFromWatchlist(item)}>löschen</button>
-      </Buttons>{' '}
+      </Buttons>
     </Card>
   );
 }
 
 const Card = styled.article`
-  width: 20rem;
+  width: 85vw;
   box-shadow: 0.3rem 0.3rem 0.8rem var(--grey-light);
   border-radius: 1.8rem;
   padding: 2rem;

--- a/client/src/components/WatchlistCards.js
+++ b/client/src/components/WatchlistCards.js
@@ -5,6 +5,7 @@ import WatchlistCard from './WatchlistCard';
 export default function WatchlistCards({
   watchlist,
   onSetItemToBeEdited,
+  onSetFormOnScreen,
   onRemoveFromWatchlist,
   onCheckItem
 }) {
@@ -14,9 +15,10 @@ export default function WatchlistCards({
         <WatchlistCard
           key={item.id}
           item={item}
-          onCheckItem={onCheckItem}
           onSetItemToBeEdited={onSetItemToBeEdited}
           onRemoveFromWatchlist={onRemoveFromWatchlist}
+          onCheckItem={onCheckItem}
+          onSetFormOnScreen={onSetFormOnScreen}
         />
       ))}
     </Grid>

--- a/client/src/components/WatchlistCards.js
+++ b/client/src/components/WatchlistCards.js
@@ -29,5 +29,5 @@ const Grid = styled.section`
   margin-top: 3rem;
   display: grid;
   justify-content: center;
-  gap: 2rem;
+  gap: 3rem;
 `;

--- a/client/src/components/WatchlistForm.js
+++ b/client/src/components/WatchlistForm.js
@@ -5,6 +5,7 @@ import { v4 as uuidv4 } from 'uuid';
 import WatchlistFormOptions from './WatchlistFormOptions';
 
 export default function WatchlistForm({
+  onSetFormOnScreen,
   onAddToWatchlist,
   itemToBeEdited,
   onSetItemToBeEdited,
@@ -55,18 +56,37 @@ export default function WatchlistForm({
       ? onEditWatchlist(formItem)
       : onAddToWatchlist({ ...formItem, id: uuidv4() });
     setFormItem(initialFormItem);
+    onSetFormOnScreen(false);
   }
 
-  function handleFormCancelation() {
+  function handleFormCancelation(event) {
+    event.preventDefault();
+    if (itemToBeEdited) {
+      onSetItemToBeEdited();
+    }
+    setFormItem(initialFormItem);
+    onSetFormOnScreen(false);
+  }
+
+  function handleFormReset() {
     if (itemToBeEdited) {
       onSetItemToBeEdited();
     }
     setFormItem(initialFormItem);
   }
 
+  function handleKeyDown(event) {
+    if (event.key === 'Enter') {
+      handleFormSubmission(event);
+    }
+  }
+
   return (
-    <Form onSubmit={handleFormSubmission}>
-      <h3>Neuen Eintrag hinzufügen</h3>
+    <Form onKeyDown={handleKeyDown} onSubmit={handleFormSubmission}>
+      <button onClick={handleFormCancelation}>x</button>
+      <h3>
+        {itemToBeEdited ? 'Eintrag bearbeiten' : 'Neuen Eintrag hinzufügen'}
+      </h3>
 
       <label>
         <span>Titel</span>
@@ -101,8 +121,8 @@ export default function WatchlistForm({
       />
 
       <Buttons>
-        <button type="reset" onClick={handleFormCancelation}>
-          abbrechen
+        <button type="reset" onClick={handleFormReset}>
+          zurücksetzen
         </button>
         <button>speichern</button>
       </Buttons>
@@ -112,9 +132,9 @@ export default function WatchlistForm({
 
 const Form = styled.form`
   margin: 0 auto;
-  max-width: 25rem;
+  xwidth: 90vw;
 
-  box-shadow: 0.3rem 0.3rem 0.8rem var(--grey-light);
+  box-shadow: 0.3rem 0.3rem 0.8rem var(--grey);
   border-radius: 1.8rem;
 
   background-color: var(--primary-lightest);
@@ -123,6 +143,11 @@ const Form = styled.form`
 
   display: grid;
   gap: 1.5rem;
+
+  button {
+    justify-self: end;
+    margin-bottom: -1rem;
+  }
 
   h3 {
     margin-bottom: 0.5rem;
@@ -138,7 +163,6 @@ const Form = styled.form`
     border-radius: 0.8rem;
     background: white;
     padding: 0.5rem;
-    border: 0.06rem black solid;
   }
 
   input {

--- a/client/src/components/WatchlistForm.js
+++ b/client/src/components/WatchlistForm.js
@@ -131,8 +131,8 @@ export default function WatchlistForm({
 }
 
 const Form = styled.form`
-  xmargin: 0 auto;
   width: 90vw;
+  max-width: 25rem;
 
   box-shadow: 0.3rem 0.3rem 0.8rem var(--grey);
   border-radius: 1.8rem;

--- a/client/src/components/WatchlistForm.js
+++ b/client/src/components/WatchlistForm.js
@@ -83,7 +83,9 @@ export default function WatchlistForm({
 
   return (
     <Form onKeyDown={handleKeyDown} onSubmit={handleFormSubmission}>
-      <button onClick={handleFormCancelation}>x</button>
+      <button className="closeButton" onClick={handleFormCancelation}>
+        x
+      </button>
       <h3>
         {itemToBeEdited ? 'Eintrag bearbeiten' : 'Neuen Eintrag hinzufügen'}
       </h3>
@@ -144,9 +146,10 @@ const Form = styled.form`
   display: grid;
   gap: 1.5rem;
 
-  button {
+  .closeButton {
     justify-self: end;
-    margin-bottom: -1rem;
+    border: none;
+    font-size: 1.7rem;
   }
 
   h3 {

--- a/client/src/components/WatchlistForm.js
+++ b/client/src/components/WatchlistForm.js
@@ -131,8 +131,8 @@ export default function WatchlistForm({
 }
 
 const Form = styled.form`
-  margin: 0 auto;
-  xwidth: 90vw;
+  xmargin: 0 auto;
+  width: 90vw;
 
   box-shadow: 0.3rem 0.3rem 0.8rem var(--grey);
   border-radius: 1.8rem;

--- a/client/src/pages/Watchlist.js
+++ b/client/src/pages/Watchlist.js
@@ -1,3 +1,6 @@
+import { useState } from 'react';
+import styled from 'styled-components';
+
 import WatchlistForm from '../components/WatchlistForm';
 import WatchlistCards from '../components/WatchlistCards';
 
@@ -10,21 +13,58 @@ export default function Watchlist({
   onRemoveFromWatchlist,
   onCheckItem
 }) {
+  const [formOnScreen, setFormOnScreen] = useState(false);
+
   return (
     <main>
-      <h2>Merkliste</h2>
-      <WatchlistForm
-        onAddToWatchlist={onAddToWatchlist}
-        itemToBeEdited={itemToBeEdited}
-        onSetItemToBeEdited={onSetItemToBeEdited}
-        onEditWatchlist={onEditWatchlist}
-      />
+      <Div>
+        <h2>Merkliste </h2>
+        <button onClick={() => setFormOnScreen(true)}>+</button>
+      </Div>
+
+      {formOnScreen && (
+        <FormWrapper>
+          <WatchlistForm
+            onSetFormOnScreen={setFormOnScreen}
+            onAddToWatchlist={onAddToWatchlist}
+            itemToBeEdited={itemToBeEdited}
+            onSetItemToBeEdited={onSetItemToBeEdited}
+            onEditWatchlist={onEditWatchlist}
+          />
+        </FormWrapper>
+      )}
       <WatchlistCards
         watchlist={watchlist}
         onSetItemToBeEdited={onSetItemToBeEdited}
+        onSetFormOnScreen={setFormOnScreen}
         onRemoveFromWatchlist={onRemoveFromWatchlist}
         onCheckItem={onCheckItem}
       />
     </main>
   );
 }
+
+const Div = styled.div`
+  display: flex;
+  justify-content: center;
+  gap: 2rem;
+
+  button {
+    height: 3rem;
+    width: 3rem;
+    border-radius: 50%;
+  }
+`;
+
+const FormWrapper = styled.div`
+  backdrop-filter: blur(0.6rem);
+  display: block;
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  display: grid;
+  place-items: center;
+  z-index: 100;
+`;

--- a/client/src/pages/Watchlist.js
+++ b/client/src/pages/Watchlist.js
@@ -47,12 +47,22 @@ export default function Watchlist({
 const TitleWrapper = styled.div`
   display: flex;
   justify-content: center;
+  align-items: center;
+  height: 100%;
   gap: 2rem;
+
+  h2 {
+    margin: 0;
+  }
 
   button {
     height: 3rem;
     width: 3rem;
     border-radius: 50%;
+    border: none;
+    background: var(--secondary-dark);
+    color: var(--primary-lightest);
+    font-size: 2rem;
   }
 `;
 

--- a/client/src/pages/Watchlist.js
+++ b/client/src/pages/Watchlist.js
@@ -57,14 +57,14 @@ const Div = styled.div`
 `;
 
 const FormWrapper = styled.div`
-  backdrop-filter: blur(0.6rem);
-  display: block;
   position: fixed;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  right: 0;
-  display: grid;
-  place-items: center;
   z-index: 100;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  backdrop-filter: blur(0.6rem);
 `;

--- a/client/src/pages/Watchlist.js
+++ b/client/src/pages/Watchlist.js
@@ -17,10 +17,10 @@ export default function Watchlist({
 
   return (
     <main>
-      <Div>
+      <TitleWrapper>
         <h2>Merkliste </h2>
         <button onClick={() => setFormOnScreen(true)}>+</button>
-      </Div>
+      </TitleWrapper>
 
       {formOnScreen && (
         <FormWrapper>
@@ -44,7 +44,7 @@ export default function Watchlist({
   );
 }
 
-const Div = styled.div`
+const TitleWrapper = styled.div`
   display: flex;
   justify-content: center;
   gap: 2rem;


### PR DESCRIPTION
Thanks for your code review :)

In Watchlist, I introduced the form as pop up window. 
It appears if you click on a plus symbol on top of the page or on EDIT in one of the Watchlist cards. 
Disappears if you click the x symbol on top of the form or submit the form.
Just in Watchlist for now, will put it into Library too later on.
Please ignore the following design for now, haven't worked on it yet: header, footer, Watchlist form, plus symbol, x symbol

See the deployed version of the pull request content [here](https://kultur-notiert-git-form-modal-felixcanditt.vercel.app/).
